### PR TITLE
update toolchain for bulding ndk version

### DIFF
--- a/build_scripts/android-configure.sh
+++ b/build_scripts/android-configure.sh
@@ -41,7 +41,7 @@ export TOOLCHAIN_INTEL=$PWD/android-toolchain-intel
 rm -rf $TOOLCHAIN_INTEL
 mkdir -p $TOOLCHAIN_INTEL
 $1/build/tools/make-standalone-toolchain.sh \
-    --toolchain=x86-4.8 \
+    --toolchain=x86-4.9 \
     --arch=x86 \
     --install-dir=$TOOLCHAIN_INTEL \
     --platform=$ANDROID_TARGET


### PR DESCRIPTION
update for Toolchain and latest NDK - 4.8 doesn't exist on Intel 86.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/jxcore/1)
<!-- Reviewable:end -->
