### PR TITLE
using utf8 instead of ascii for psk identity and deal with CDN change for binaries

### DIFF
--- a/deps/packnpm.sh
+++ b/deps/packnpm.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-VER=311
+VER=312
 tar -zcvf npmjx$VER.tar.gz npm
 cp npmjx$VER.tar.gz ~/.jx/
 cd ~/.jx/

--- a/lib/jx/_jx_install.js
+++ b/lib/jx/_jx_install.js
@@ -125,8 +125,8 @@ exports.install = function() {
   };
 
   var name = '';
-  var npm_basename = 'npmjxv311.jx';
-  var npm_str = 'https://s3.amazonaws.com/nodejx/' + npm_basename;
+  var npm_basename = 'npmjxv312.jx';
+  var npm_str = 'https://jxcore.azureedge.net/npmjx/' + npm_basename;
   var isWindows = process.platform === 'win32';
   var isAndroid = process.platform === 'android';
   var homeFolder = process.env.HOME ||

--- a/src/wrappers/node_crypto.cc
+++ b/src/wrappers/node_crypto.cc
@@ -2070,8 +2070,8 @@ unsigned int node::crypto::
 
     if (JS_IS_STRING(id) && Buffer::HasInstance(key)) {
       // write the chosen client identity string into the buffer provided
-      ssize_t hlen = StringBytes::JXSize(id, ASCII, false);
-      StringBytes::JXWrite(identity, hlen, id, ASCII, false);
+      ssize_t hlen = StringBytes::JXSize(id, UTF8, false);
+      StringBytes::JXWrite(identity, hlen, id, UTF8, false);
 
       // write the id's binary key into the buffer provided
       JS_LOCAL_OBJECT(keyBuffer) = JS_VALUE_TO_OBJECT(key);

--- a/tools/npmjx/index.js
+++ b/tools/npmjx/index.js
@@ -196,7 +196,7 @@ var gonpm = function () {
 
 jxcore.utils.console.log("Downloading NPM for JXcore", "yellow");
 
-download("https://s3.amazonaws.com/nodejx/npmjx311.tar.gz", npmloc + ".tar.gz", function () {
+download("https://jxcore.azureedge.net/npmjx/npmjx312.tar.gz", npmloc + ".tar.gz", function () {
   try {
     var targz = require('tar.gz');
   } catch (ex) {
@@ -204,6 +204,7 @@ download("https://s3.amazonaws.com/nodejx/npmjx311.tar.gz", npmloc + ".tar.gz", 
     process.exit(1);
     return;
   }
+  jxcore.utils.console.log("extracting " + npmloc + ".tar.gz", "yellow");
   extract(npmloc + ".tar.gz", __dirname, function (isdone, msg) {
 
     if (!isdone) {

--- a/tools/npmjx/npmjx.jxp
+++ b/tools/npmjx/npmjx.jxp
@@ -1,6 +1,6 @@
 {
     "name": "npmjx",
-    "version": "3.1.1",
+    "version": "3.1.2",
     "author": "JXcore contributors",
     "description": "NPM wrapper for JXcore",
     "company": "Nubisa Inc.",
@@ -9,7 +9,7 @@
     "startup": "index.js",
     "execute": "index.js",
     "extract": false,
-    "output": "npmjxv311.jx",
+    "output": "npmjxv312.jx",
 	"files": [
 		"index.js",
 		"node_modules/tar.gz/example/example.js",


### PR DESCRIPTION
This updates to use UTF8 instead of ASCII on reading the PskIdentity provided. This doesn't affect Thali right now as the string presented will be base64 encoded, thus only ASCII.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/jxcore/4)
<!-- Reviewable:end -->
