### PR TITLE
Fix #8 Externalize the paths.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,8 @@ icu_config.gypi
 icu_config.gypi
 *.opendb
 browse.VC.db
+
+# files that are created at build time from templates
+deps/npm/lib/_jx.js
+lib/jx/_jx_install.js
+tools/npmjx/index.js

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ jx_g: config.gypi out/Makefile
 	ln -fs out/Debug/jx $@
 endif
 
-out/Makefile: common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp deps/zlib/zlib.gyp jx.gyp config.gypi
+out/Makefile: replace-urls common.gypi deps/uv/uv.gyp deps/http_parser/http_parser.gyp deps/zlib/zlib.gyp jx.gyp config.gypi
 ifeq ($(USE_NINJA),1)
 	touch out/Makefile
 	$(PYTHON) tools/gyp_node.py -f ninja
@@ -84,6 +84,9 @@ distclean:
 	-rm -rf node_modules
 	-rm -rf deps/icu
 	-rm -rf deps/icu4c*.tgz deps/icu4c*.zip deps/icu-tmp
+
+replace-urls:
+	-sh ./build_scripts/replace_urls/replace_lib_jx.sh
 
 test: all
 	$(PYTHON) tools/test.py --mode=release simple

--- a/build_scripts/replace_urls/deps-npm-lib-_jx.js.template
+++ b/build_scripts/replace_urls/deps-npm-lib-_jx.js.template
@@ -45,8 +45,8 @@ exports.setVariables = function() {
   //process.env["SKIP_SASS_BINARY_DOWNLOAD_FOR_CI"] = true
 
   // for node-gyp
-  process.env["NVM_NODEJS_ORG_MIRROR"] = "https://jxcore.azureedge.net"
-  process.env["JX_NPM_JXB"] = "jxb311"
+  process.env["NVM_NODEJS_ORG_MIRROR"] = "${NVM_NODEJS_ORG_MIRROR}"
+  process.env["JX_NPM_JXB"] = "${JX_NPM_JXB}"
 
   // this allows to use for replacement "/full/path/to/jx" rather than only "jx"
   arg_useExecPath = process.argv.indexOf('--jx-use-exec-path') !== -1

--- a/build_scripts/replace_urls/lib-jx-_jx_install.js.template
+++ b/build_scripts/replace_urls/lib-jx-_jx_install.js.template
@@ -125,8 +125,8 @@ exports.install = function() {
   };
 
   var name = '';
-  var npm_basename = 'npmjxv311b.jx';
-  var npm_str = 'https://jxcore.azureedge.net/npmjx/' + npm_basename;
+  var npm_basename = '${NPMJX_PROXY_BASENAME}';
+  var npm_str = '${NPMJX_PROXY_PARENTURL}' + npm_basename;
   var isWindows = process.platform === 'win32';
   var isAndroid = process.platform === 'android';
   var homeFolder = process.env.HOME ||

--- a/build_scripts/replace_urls/replace_lib_jx.sh
+++ b/build_scripts/replace_urls/replace_lib_jx.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# This script is called by Makefile to create lib/jx/_jx_install.js at build
+# time
+
+cd build_scripts/replace_urls/
+python replace_urls.py lib-jx-_jx_install.js.template

--- a/build_scripts/replace_urls/replace_urls.json
+++ b/build_scripts/replace_urls/replace_urls.json
@@ -1,0 +1,30 @@
+{
+	"files": [{
+		"template": "tools-npmjx-index.js.template",
+		"destination": "../../tools/npmjx/index.js",
+		"url": [{
+			"id": "${NPMJX_URL}",
+			"value": "https://jxcore.azureedge.net/npmjx/npmjx311b.tar.gz"
+		}]
+	}, {
+		"template": "lib-jx-_jx_install.js.template",
+		"destination": "../../lib/jx/_jx_install.js",
+		"url": [{
+			"id": "${NPMJX_PROXY_BASENAME}",
+			"value": "npmjxv311b.jx"
+		}, {
+			"id": "${NPMJX_PROXY_PARENTURL}",
+			"value": "https://jxcore.azureedge.net/npmjx/"
+		}]
+	}, {
+		"template": "deps-npm-lib-_jx.js.template",
+		"destination": "../../deps/npm/lib/_jx.js",
+		"url": [{
+			"id": "${NVM_NODEJS_ORG_MIRROR}",
+			"value": "https://jxcore.azureedge.net"
+		}, {
+			"id": "${JX_NPM_JXB}",
+			"value": "jxb311"
+		}]
+	}]
+}

--- a/build_scripts/replace_urls/replace_urls.py
+++ b/build_scripts/replace_urls/replace_urls.py
@@ -1,0 +1,24 @@
+# This script is used to create files from templates and replace
+# place-holders ids with values defined in replace_urls.json.
+# The values are urls to the:
+# - npm proxy module
+# - npm module
+# - node-gyp
+
+import sys
+import json
+
+if len(sys.argv) != 2:
+    sys.exit(1)
+
+with open('replace_urls.json') as data_file:    
+    data = json.load(data_file)
+
+for file_to_process in data["files"]:
+    if sys.argv[1] == file_to_process["template"]:
+        with open(file_to_process["destination"], "wt") as fout:
+            with open(file_to_process["template"], "rt") as fin:
+                for line in fin:
+                    for url in file_to_process["url"]:
+                        line = line.replace(url["id"], url["value"])
+                    fout.write(line)

--- a/build_scripts/replace_urls/tools-npmjx-index.js.template
+++ b/build_scripts/replace_urls/tools-npmjx-index.js.template
@@ -196,7 +196,7 @@ var gonpm = function () {
 
 jxcore.utils.console.log("Downloading NPM for JXcore", "yellow");
 
-download("https://jxcore.azureedge.net/npmjx/npmjx311b.tar.gz", npmloc + ".tar.gz", function () {
+download("${NPMJX_URL}", npmloc + ".tar.gz", function () {
   try {
     var targz = require('tar.gz');
   } catch (ex) {

--- a/deps/packnpm.sh
+++ b/deps/packnpm.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # deps/npm/lib/_jx.js contains a url to the node-gyp module used by jx/
-# the deps/npm/lib/_jx.js is created from a templated invoking the 
-# replace_urls.py script. The url to node-gyp can be changed editing
+# the deps/npm/lib/_jx.js is created from a template invoking the
+# replace_urls.py script. The url to node-gyp can be changed by editing
 # the template: build_scripts/replace_urls/deps-npm-lib-_jx.js.template
 
 cwd=$(pwd)

--- a/deps/packnpm.sh
+++ b/deps/packnpm.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
+
+# deps/npm/lib/_jx.js contains a url to the node-gyp module used by jx/
+# the deps/npm/lib/_jx.js is created from a templated invoking the 
+# replace_urls.py script. The url to node-gyp can be changed editing
+# the template: build_scripts/replace_urls/deps-npm-lib-_jx.js.template
+
+cwd=$(pwd)
+cd ../build_scripts/replace_urls/
+python replace_urls.py deps-npm-lib-_jx.js.template
+cd $cwd
+
 VER=311b
 tar -zcvf npmjx$VER.tar.gz npm
 cp npmjx$VER.tar.gz ~/.jx/

--- a/tools/npmjx/compile_npmjx.sh
+++ b/tools/npmjx/compile_npmjx.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# npmjx is a proxy module downloaded by jx when 'jx npm install'
+# is invoked.
+# npmjx is created running this script from within tools/npmjx.
+# It calls the replace_urls.py script to create index.js and then
+# it compiles nmpjx.jxp to create the npm proxy module.
+# The npm proxy module contains at index.js:199 the url to download
+# the npm module, that url that can be changed by editing:
+# build_scripts/replace_urls/tools-npmjx-index.js.template
+# after the template has been change, please re-run this script.
+
+cwd=$(pwd)
+cd ../../build_scripts/replace_urls/
+python replace_urls.py tools-npmjx-index.js.template
+cd $cwd
+jx compile npmjx.jxp

--- a/tools/npmjx/compile_npmjx.sh
+++ b/tools/npmjx/compile_npmjx.sh
@@ -5,8 +5,8 @@
 # npmjx is created running this script from within tools/npmjx.
 # It calls the replace_urls.py script to create index.js and then
 # it compiles nmpjx.jxp to create the npm proxy module.
-# The npm proxy module contains at index.js:199 the url to download
-# the npm module, that url that can be changed by editing:
+# The npm proxy module defines in index.js the url to download
+# the npm module, that url can be changed by editing:
 # build_scripts/replace_urls/tools-npmjx-index.js.template
 # after the template has been change, please re-run this script.
 

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -167,6 +167,17 @@ SETLOCAL
 ENDLOCAL
 
 :msbuild
+SETLOCAL
+  call :getpythonversion
+  if errorlevel 1 goto exit
+  
+  cd build_scripts\replace_urls\
+  echo %cd%
+  python replace_urls.py lib-jx-_jx_install.js.template
+  if errorlevel 1 goto replace-url-failed
+  echo NPM Url replaced
+ENDLOCAL
+
 @rem Build the sln with msbuild.
 msbuild jx.sln /m /t:%target% /p:Configuration="%config%" %c_platform% /clp:NoSummary;NoItemAndPropertyList;Verbosity=minimal /nologo
 goto exit
@@ -234,6 +245,10 @@ goto exit
 
 :create-msvs-files-failed
 echo Failed to create vc project files. 
+goto exit
+
+:replace-url-failed
+echo Failed to replace urls from template. 
 goto exit
 
 :upload


### PR DESCRIPTION
Jxcore uses its own npm version and the urls to the modules were hardcoded.
Issue https://github.com/thaliproject/jxcore/issues/8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/jxcore/17)
<!-- Reviewable:end -->


<!---
@huboard:{"order":2.9789729720607083e-08,"milestone_order":17.0,"custom_state":""}
-->
