### PR TITLE
Add SIGSEGV handler on Linux and Android.

### DIFF
--- a/deps/mozjs/incs/mozilla/ThreadLocal.h
+++ b/deps/mozjs/incs/mozilla/ThreadLocal.h
@@ -78,11 +78,25 @@ class ThreadLocal
   typedef pthread_key_t key_t;
 #endif
 
-  union Helper
+  // The 'Helper' function has been updated using the SpiderMonkey 38.0.5
+  // version.
+
+  // Integral types narrower than void* must be extended to avoid
+  // warnings from valgrind on some platforms.  This helper type
+  // achieves that without penalizing the common case of ThreadLocals
+  // instantiated using a pointer type.
+  template<typename S>
+  struct Helper
   {
-    void* mPtr;
-    T mValue;
-  };
+    typedef uintptr_t Type;
+  };  
+
+  template<typename S>
+  struct Helper<S *>
+  {
+    typedef S *Type;
+  };  
+
 
 public:
   MOZ_WARN_UNUSED_RESULT inline bool init();
@@ -102,9 +116,14 @@ template<typename T>
 inline bool
 ThreadLocal<T>::init()
 {
+  static_assert(mozilla::IsPointer<T>::value || mozilla::IsIntegral<T>::value,
+              "mozilla::ThreadLocal must be used with a pointer or "
+              "integral type");
+
   static_assert(sizeof(T) <= sizeof(void*),
                 "mozilla::ThreadLocal can't be used for types larger than "
                 "a pointer");
+
   MOZ_ASSERT(!initialized());
 #ifdef XP_WIN
   mKey = TlsAlloc();
@@ -120,13 +139,13 @@ inline T
 ThreadLocal<T>::get() const
 {
   MOZ_ASSERT(initialized());
-  Helper h;
+  void *h;
 #ifdef XP_WIN
-  h.mPtr = TlsGetValue(mKey);
+  h = TlsGetValue(mKey);
 #else
-  h.mPtr = pthread_getspecific(mKey);
+  h = pthread_getspecific(mKey);
 #endif
-  return h.mValue;
+  return static_cast<T>(reinterpret_cast<typename Helper<T>::Type>(h));
 }
 
 template<typename T>
@@ -134,12 +153,11 @@ inline void
 ThreadLocal<T>::set(const T aValue)
 {
   MOZ_ASSERT(initialized());
-  Helper h;
-  h.mValue = aValue;
+  void* h = reinterpret_cast<void*>(static_cast<typename Helper<T>::Type>(aValue));
 #ifdef XP_WIN
-  bool succeeded = TlsSetValue(mKey, h.mPtr);
+  bool succeeded = TlsSetValue(mKey, h);
 #else
-  bool succeeded = !pthread_setspecific(mKey, h.mPtr);
+  bool succeeded = !pthread_setspecific(mKey, h);
 #endif
   if (!succeeded) {
     MOZ_CRASH();

--- a/deps/mozjs/mozjs.gyp
+++ b/deps/mozjs/mozjs.gyp
@@ -234,7 +234,12 @@
       ],
       'configurations': {
         'Debug': {
-          'defines': [ 'JS_DEBUG' ]
+          'defines': [ 'JS_DEBUG' ],
+          'conditions': [
+            [ 'OS == "linux" and target_arch == "x64"', {
+              'cflags_cc': [ '-fpermissive' ],
+              }],
+          ],
         },
         'Release': {
           'defines': ['NDEBUG'],

--- a/deps/mozjs/src/vm/Runtime.h
+++ b/deps/mozjs/src/vm/Runtime.h
@@ -608,7 +608,7 @@ class PerThreadData : public PerThreadDataFriendFields
         return asmJSActivationStack_;
     }
     static js::AsmJSActivation *innermostAsmJSActivation() {
-        PerThreadData *ptd = TlsPerThreadData.get();
+        PerThreadData *ptd = js::TlsPerThreadData.get();
         return ptd ? ptd->asmJSActivationStack_ : nullptr;
     }
 
@@ -1444,7 +1444,7 @@ namespace js {
 static inline JSContext *
 GetJSContextFromJitCode()
 {
-    JSContext *cx = TlsPerThreadData.get()->jitJSContext;
+    JSContext *cx = js::TlsPerThreadData.get()->jitJSContext;
     JS_ASSERT(cx);
     return cx;
 }

--- a/src/jxcore.cc
+++ b/src/jxcore.cc
@@ -353,6 +353,7 @@ char **JXEngine::Init(int argc, char *argv[], bool engine_inited_already) {
     RegisterSignalHandler(SIGPIPE, SIG_IGN);
     RegisterSignalHandler(SIGINT, SignalExit);
     RegisterSignalHandler(SIGTERM, SignalExit);
+    RegisterSignalHandler(SIGSEGV, SignalExit);
 #endif  // __POSIX__
   }
 

--- a/test/simple/test-regress-GH-4015.js
+++ b/test/simple/test-regress-GH-4015.js
@@ -18,5 +18,10 @@ exec(cmd, function(err, stdout, stderr) {
   if(process.versions.v8)
     assert(/RangeError: Maximum call stack size exceeded/.test(stderr));
   else
-    assert(err.signal == "SIGSEGV");
+    // On recent Ubuntu releases the test was failing because the 
+    // err.signal value doesn't get set properly.
+    // The current fix in JXcore catches the SIGSEGV signal at a place
+    // where is too late to get the err object filled properly, therefore
+    // in the test we need to use the error code value (128 + 11).
+    assert(err.code == 139 || err.signal == "SIGSEGV" );
 });


### PR DESCRIPTION
Fixes https://github.com/thaliproject/jxcore/issues/22 and prevent app crash on Android https://github.com/thaliproject/Thali_CordovaPlugin/issues/563

Adding a new Registered signal handler for SIGSEGV for Linux.
When the system rises a SIGSGEV the registred handler will call
the SignalExit function.

Extending  integral types narrower than void* must be extended to avoid
warnings from some platforms.  This is obtained changing the helper
union in two overrided struct for integer pointers and generic pointer. This
achieves the goal without penalizing the common case of ThreadLocals
instantiated using a pointer type. This change was taken from Mozilla
SpiderMonkey rel. 38.0.5.

Adding -f permissive flag for debug compiling (Linux).
The compilation under Linux Fails without this flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/jxcore/49)
<!-- Reviewable:end -->