### PR TITLE
fix: round float value in setTimeout/setInterval to int.

### DIFF
--- a/lib/timers.js
+++ b/lib/timers.js
@@ -211,6 +211,7 @@ exports.setTimeout = function(callback, after) {
   var timer;
 
   after *= 1; // coalesce to number or NaN
+  after = parseInt(after);  // round float to int
 
   if (!(after >= 1 && after <= TIMEOUT_MAX)) {
     after = 1; // schedule on next tick, follows browser behaviour
@@ -258,6 +259,7 @@ exports.clearTimeout = function(timer) {
 
 exports.setInterval = function(callback, repeat) {
   repeat *= 1; // coalesce to number or NaN
+  repeat = parseInt(repeat); // round float to int
 
   if (!(repeat >= 1 && repeat <= TIMEOUT_MAX)) {
     repeat = 1; // schedule on next tick, follows browser behaviour


### PR DESCRIPTION
On mobile devices, using a float value for setTimout/setInterval
causes the timer to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/thaliproject/jxcore/78)
<!-- Reviewable:end -->
